### PR TITLE
fix(lib): Fix extern crate statement for rustc_serialize

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,8 @@
-#![crate_name = "jsonway"]
 #![crate_type = "rlib"]
 #![deny(warnings)]
 #![deny(bad_style)]
 #![feature(collections)]
-extern crate "rustc-serialize" as serialize;
+extern crate rustc_serialize as serialize;
 extern crate collections;
 
 pub use mutable_json::MutableJson;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,4 +1,4 @@
-extern crate "rustc-serialize" as serialize;
+extern crate rustc_serialize as serialize;
 extern crate jsonway;
 
 #[derive(Debug)]


### PR DESCRIPTION
There where changes in the way the rust toolchain handles
hyphens in crate names.