### PR TITLE
updated lib.rs to compile on rust beta

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,7 @@
 #![crate_type = "rlib"]
 #![deny(warnings)]
 #![deny(bad_style)]
-#![feature(collections)]
 extern crate rustc_serialize as serialize;
-extern crate collections;
 
 pub use mutable_json::MutableJson;
 pub use object_builder::ObjectBuilder;


### PR DESCRIPTION
collections is part of std (and is correctly use in array_builder / object_builder) so there's no need to add the flag to activate this feature (which is the reason why it was failing in rust beta) 