### PR TITLE
Update to `serde` 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "jsonway"
-version = "1.0.1"
+version = "2.0.0"
 authors = ["Stanislav Panferov <fnight.m@gmail.com>"]
 description = "JSON building DSL and configurable serializers for Rust"
 repository = "https://github.com/rustless/jsonway"
@@ -10,8 +10,8 @@ keywords = ["json", "serializers"]
 license = "MIT"
 
 [dependencies]
-serde = "0.8"
-serde_json = "0.8"
+serde = "1.0"
+serde_json = "1.0"
 
 [[test]]
 name = "tests"

--- a/src/array_builder.rs
+++ b/src/array_builder.rs
@@ -1,6 +1,5 @@
 use serde_json::{Value, to_value};
 use serde::{Serialize, Serializer};
-use std::collections;
 
 pub type JsonArray = Vec<Value>;
 
@@ -84,7 +83,7 @@ impl ArrayBuilder {
     /// Move out internal JSON value.
     pub fn unwrap(self) -> Value {
         if self.root.is_some() {
-            let mut obj = collections::BTreeMap::new();
+            let mut obj = ::serde_json::Map::new();
             let root = self.root.as_ref().unwrap().to_string();
             let self_json = self.unwrap_internal();
             obj.insert(root, self_json);
@@ -108,7 +107,7 @@ impl ArrayBuilder {
 impl ArrayBuilder {
     /// Push to array something that can be converted to JSON.
     pub fn push<T: Serialize>(&mut self, value: T) {
-        self.push_json(to_value(&value));
+        self.push_json(to_value(&value).unwrap());
     }
 }
 
@@ -146,8 +145,8 @@ impl ArrayBuilder {
 
 impl Serialize for ArrayBuilder {
     /// Copy self to new JSON instance.
-    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error> where S: Serializer {
-        let json_object = if self.null { Value::Null } else { to_value(&self.array) };
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+        let json_object = if self.null { Value::Null } else { to_value(&self.array).unwrap() };
         json_object.serialize(serializer)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,11 +34,11 @@ pub mod array_serializer;
 ///     });
 /// }).unwrap();
 ///
-/// assert_eq!(json.find("first_name").unwrap().as_str().unwrap(), "Luke");
-/// assert_eq!(json.find("last_name").unwrap().as_str().unwrap(), "Skywalker");
+/// assert_eq!(json.get("first_name").unwrap().as_str().unwrap(), "Luke");
+/// assert_eq!(json.get("last_name").unwrap().as_str().unwrap(), "Skywalker");
 ///
-/// assert!(json.find("info").unwrap().is_object());
-/// assert!(json.find("masters").unwrap().is_array());
+/// assert!(json.get("info").unwrap().is_object());
+/// assert!(json.get("masters").unwrap().is_array());
 /// ```
 
 /// Create and return new ListBuilder

--- a/src/object_builder.rs
+++ b/src/object_builder.rs
@@ -1,8 +1,7 @@
-use std::collections::{BTreeMap};
 use serde_json::{Value, to_value};
 use serde::{Serialize, Serializer};
 
-pub type Object = BTreeMap<String, Value>;
+pub type Object = ::serde_json::Map<String, Value>;
 use array_builder;
 
 pub struct ObjectBuilder {
@@ -16,7 +15,7 @@ pub struct ObjectBuilder {
 impl ObjectBuilder {
     pub fn new() -> ObjectBuilder {
         ObjectBuilder {
-            object: BTreeMap::new(),
+            object: ::serde_json::Map::new(),
             null: false,
             skip: false,
             root: None
@@ -66,7 +65,7 @@ impl ObjectBuilder {
     /// Move out internal JSON value.
     pub fn unwrap(self) -> Value {
         if self.root.is_some() {
-            let mut obj = BTreeMap::new();
+            let mut obj = ::serde_json::Map::new();
             let root = self.root.as_ref().unwrap().to_string();
             let self_json = self.unwrap_internal();
             obj.insert(root, self_json);
@@ -90,7 +89,7 @@ impl ObjectBuilder {
     /// Set object's `name` field with something that can be
     /// converted to Value value.
     pub fn set<V: Serialize, N: Into<String>>(&mut self, name: N, value: V) {
-        self.set_json(name, to_value(&value));
+        self.set_json(name, to_value(&value).unwrap());
     }
 
     /// Stub for future use
@@ -118,8 +117,8 @@ impl ObjectBuilder {
 
 impl Serialize for ObjectBuilder {
     /// Copy self to new JSON instance.
-    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error> where S: Serializer {
-        let json_object = if self.null { Value::Null } else { to_value(&self.object) };
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+        let json_object = if self.null { Value::Null } else { to_value(&self.object).unwrap() };
         json_object.serialize(serializer)
     }
 }

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -27,10 +27,7 @@ use object_builder;
 /// let json = JediSerializer{jedi: &jedi}.serialize(true);
 ///
 /// assert_eq!(
-///     json.find_path(&[
-///         "jedi",
-///         "name",
-///     ]).unwrap().as_str().unwrap(),
+///     json.pointer("/jedi/name").unwrap().as_str().unwrap(),
 ///     "Saes Rrogon"
 /// );
 /// ```
@@ -79,10 +76,7 @@ pub trait Serializer {
 /// let json = JediSerializer.serialize(&jedi, true);
 ///
 /// assert_eq!(
-///     json.find_path(&[
-///         "jedi",
-///         "name",
-///     ]).unwrap().as_str().unwrap(),
+///     json.pointer("/jedi/name").unwrap().as_str().unwrap(),
 ///     "Saes Rrogon"
 /// );
 /// ```
@@ -145,18 +139,12 @@ pub trait ObjectSerializer<T> {
 /// let json = JediSerializer.serialize(&jedi, &current_user, true);
 ///
 /// assert_eq!(
-///     json.find_path(&[
-///         "jedi",
-///         "name",
-///     ]).unwrap().as_str().unwrap(),
+///     json.pointer("/jedi/name").unwrap().as_str().unwrap(),
 ///     "Palpatine"
 /// );
 ///
 /// assert_eq!(
-///     json.find_path(&[
-///         "jedi",
-///         "secret",
-///     ]).unwrap().as_str().unwrap(),
+///     json.pointer("/jedi/secret").unwrap().as_str().unwrap(),
 ///     "Dark side"
 /// );
 ///


### PR DESCRIPTION
* BREAKING CHANGE: Force the current doc examples to `unwrap` their code, since now
    `serde_json::to_value` returns a `Result`.
* BREAKING CHANGE: Make downstream update any custom serializers they may have used to conform to the new `serde` API. This is expected, and not too big of a deal for people who want to upgrade to the new versions of `serde`. Basically, one only needs to change the `&mut S` argument to `S`, and use `S::Ok` instead of `()` for the `Result`.
* BREAKING CHANGE: Rename `find` usages in the docs to its isomorphic successor API `get`.

---

Things that may be interesting to discuss in this PR:
* The SemVer version bump that (I think) should accompany this change, since the APIs and docs have changed sufficiently to break most client code.